### PR TITLE
fix bug in webhook matchLabels

### DIFF
--- a/servicemonitor.yaml
+++ b/servicemonitor.yaml
@@ -69,7 +69,7 @@ spec:
     - knative-serving
   selector:
     matchLabels:
-      app: activator
+      app: webhook
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
Webhook pods have the label `app: webhook`, not `app: activator`.