### PR TITLE
Fix metrics names

### DIFF
--- a/grafana/dashboards.yaml
+++ b/grafana/dashboards.yaml
@@ -4632,7 +4632,7 @@ data:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 1,
@@ -4647,7 +4647,7 @@ data:
                 "refId": "B"
               },
               {
-                "expr": "sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "Core limit",
@@ -4739,7 +4739,7 @@ data:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 1,
@@ -4755,9 +4755,10 @@ data:
                 "refId": "B"
               },
               {
-                "expr": "sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+                "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
                 "format": "time_series",
                 "intervalFactor": 1,
+                "legendFormat": "Memory limit",
                 "refId": "C"
               }
             ],

--- a/grafana/knative-scaling.json
+++ b/grafana/knative-scaling.json
@@ -314,7 +314,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+            "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -329,7 +329,7 @@
             "refId": "B"
           },
           {
-            "expr": "sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+            "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Core limit",
@@ -421,7 +421,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+            "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -437,9 +437,10 @@
             "refId": "B"
           },
           {
-            "expr": "sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
+            "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", namespace=\"$namespace\", pod=~\"$revision-deployment-.*\"})",
             "format": "time_series",
             "intervalFactor": 1,
+            "legendFormat": "Memory limit",
             "refId": "C"
           }
         ],


### PR DESCRIPTION
Starting with kube-state-metrics v2.0.0, `kube_pod_container_resource_(requests|limits)_(cpu_cores|memory_bytes)` has been removed and merged into `kube_pod_container_resource_(requests|limits)`. So change to use them.

https://github.com/kubernetes/kube-state-metrics/blob/release-2.0/CHANGELOG.md

In addition, add `legendFormat` "Memory Limit" because it was missing.