### PR TITLE
Fix generate-configmap.sh

### DIFF
--- a/hack/generate-configmap.sh
+++ b/hack/generate-configmap.sh
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 rm -rf hack/charts/dashboards
-mkdir hack/charts/dashboards
 cp -r grafana/ hack/charts/dashboards
 helm template hack/charts/ > grafana/dashboards.yaml
 sed -i.bak '/knative-dashboards.yaml/d' grafana/dashboards.yaml


### PR DESCRIPTION
The directory structure and script did not match and could not be generated properly.