### PR TITLE
Fix metrics name

### DIFF
--- a/grafana/dashboards.yaml
+++ b/grafana/dashboards.yaml
@@ -4866,10 +4866,10 @@ data:
                 "refId": "A"
               },
               {
-                "expr": "sum(autoscaler_observed_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
+                "expr": "sum(autoscaler_actual_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
                 "format": "time_series",
                 "intervalFactor": 1,
-                "legendFormat": "Observed Pods",
+                "legendFormat": "Actual Pods",
                 "refId": "B"
               }
             ],

--- a/grafana/knative-scaling.json
+++ b/grafana/knative-scaling.json
@@ -548,10 +548,10 @@
             "refId": "A"
           },
           {
-            "expr": "sum(autoscaler_observed_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
+            "expr": "sum(autoscaler_actual_pods{namespace_name=\"$namespace\", configuration_name=\"$configuration\", revision_name=\"$revision\"})",
             "format": "time_series",
             "intervalFactor": 1,
-            "legendFormat": "Observed Pods",
+            "legendFormat": "Actual Pods",
             "refId": "B"
           }
         ],


### PR DESCRIPTION
Since there is (no longer?) a metric called `autoscaler_observed_pods`, change it to use `autoscaler_actual_pods` instead.